### PR TITLE
Landing site boiler plate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # volunteero-gates
 
-> Volunteero authorization service frontend in Vue.js
+> Volunteero landing site frontend.
+> Written in Vue.js, paired with authorization and public discovery serivces.
 
 ## Build Setup
 

--- a/index.html
+++ b/index.html
@@ -15,9 +15,11 @@
   <!-- CSS -->
   <link rel="stylesheet" href="./static/css/normalize.css">
   <link rel="stylesheet" href="./static/css/skeleton.css">
-
+  
   <!-- From CDN -->
   <script src="https://unpkg.com/vue-swal"></script>
+  <!-- Lnr Icon Font -->
+  <link rel="stylesheet" href="https://cdn.linearicons.com/free/1.0.0/icon-font.min.css">
 
 </head>
 

--- a/src/components/auth/login/Login.vue
+++ b/src/components/auth/login/Login.vue
@@ -35,7 +35,7 @@
 
 <script>
 import axios from 'axios';
-import WindowEvents from '../../mixins/WindowEvents';
+import WindowEvents from '../../../mixins/WindowEvents';
 
 export default {
   data() {

--- a/src/components/auth/register/Register.vue
+++ b/src/components/auth/register/Register.vue
@@ -36,7 +36,7 @@
 <script>
 // TODO: this all looks very annoying and duplicating code
 import axios from 'axios';
-import WindowEvents from '../../mixins/WindowEvents';
+import WindowEvents from '../../../mixins/WindowEvents';
 
 export default {
   data() {

--- a/src/components/discover/Discover.vue
+++ b/src/components/discover/Discover.vue
@@ -1,15 +1,46 @@
 <template>
   <div class="container">
+    <!-- Search input -->
     <div class="section row">
       <div class="six columns offset-by-three">
-        <input class="u-full-width" type="text" placeholder="I am interested in...">
+        <input class="u-full-width"
+          type="text"
+          v-model="search.term"
+          @change="lookup"
+          placeholder="I am interested in...">
       </div>
     </div>
+
+    <!-- Search categories -->
     <div class="row">
-      <div v-for="category in search.categories" :key="category.name">
-        {{category}}
+      <div class="eight columns offset-by-two">
+        <div
+          class="four columns"
+          v-for="category in search.categories"
+          :key="category.name">
+          <button
+            :class="{ 'button-primary': category.selected,}"
+            class="standard-size"
+            @click="category.selected = !category.selected">
+              <i
+                class="lnr"
+                :class="{'lnr-cloud': !category.selected, 'lnr-sun': category.selected}"
+              ></i>
+              {{category.name}}
+          </button>
+        </div>
       </div>
     </div>
+
+    <!-- Search results -->
+    <div class="row">
+      <div class="six columns offset-by-three">
+        <p>Found: {{resultNumber}} | Among:
+          <span v-for='sc in searchCategories' :key="sc.name">{{sc.name}} </span> </p>
+      </div>
+    </div>
+
+    <!-- TODO: add the result rendering component -->
   </div>
 </template>
 
@@ -19,10 +50,12 @@ export default {
   data() {
     return {
       search: {
+        term: '',
+        lastTerm: '',
         categories: [
           {
             name: 'events',
-            selected: false,
+            selected: true,
           },
           {
             name: 'campaigns',
@@ -33,8 +66,32 @@ export default {
             selected: false,
           },
         ],
+        results: [],
       },
     };
+  },
+  computed: {
+    resultNumber() {
+      return this.search.results.length;
+    },
+    searchCategories() {
+      const searchCategories = this.search.categories.filter(
+        cat => cat.selected,
+      );
+      console.log(searchCategories);
+      return (searchCategories.length === 0) ? [{ name: 'everything' }] : searchCategories;
+    },
+  },
+  methods: {
+    lookup() {
+      const newTerm = this.search.term;
+      const oldTerm = this.search.lastTerm;
+      if (newTerm !== oldTerm) {
+        this.search.results = [
+          { name: 'Dummy', description: 'I am a dummy search result', newTerm },
+        ];
+      }
+    },
   },
 };
 </script>

--- a/src/components/discover/Discover.vue
+++ b/src/components/discover/Discover.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="container">
+    <div class="section row">
+      <div class="six columns offset-by-three">
+        <input class="u-full-width" type="text" placeholder="I am interested in...">
+      </div>
+    </div>
+    <div class="row">
+      <div v-for="category in search.categories" :key="category.name">
+        {{category}}
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Discover',
+  data() {
+    return {
+      search: {
+        categories: [
+          {
+            name: 'events',
+            selected: false,
+          },
+          {
+            name: 'campaigns',
+            selected: false,
+          },
+          {
+            name: 'organizations',
+            selected: false,
+          },
+        ],
+      },
+    };
+  },
+};
+</script>
+

--- a/src/components/landing/Landing.vue
+++ b/src/components/landing/Landing.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="container">
+
+    <!-- Caption phrase -->
+    <div class="section row u-left-align">
+      <div class="6 columns offset-by-one">
+        <h1>{{ msg }}</h1>
+        <h4>{{ sub }}</h4>
+      </div>
+    </div>
+
+    <!-- Auth / Discover incentives -->
+    <div class="section row u-left-align">
+      <div class="6 columns offset-by-one">
+        <!-- <p><i>Volunteero = Volunteer + Hero</i></p> -->
+        <p>
+          <router-link :to="'/auth/login'">Join us</router-link>
+          or
+          <router-link :to="'/discover'">discover</router-link>
+          the community
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Landing',
+  data() {
+    return {
+      msg: 'Volunteero',
+      sub: 'Helping you help the world',
+    };
+  },
+};
+</script>
+

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,17 +1,24 @@
 import Vue from 'vue';
 import Router from 'vue-router';
-import HelloWorld from '@/components/HelloWorld';
-import Login from '@/components/login/Login';
-import Register from '@/components/register/Register';
+// // Debug
+// import HelloWorld from '@/components/HelloWorld';
+// Landing
+import Landing from '@/components/landing/Landing';
+// Auth Routes
+import Login from '@/components/auth/login/Login';
+import Register from '@/components/auth/register/Register';
+// Discover Route
+import Discover from '@/components/discover/Discover';
 
 Vue.use(Router);
 
 export default new Router({
+  mode: 'history',
   routes: [
     {
       path: '/',
-      name: 'HelloWorld',
-      component: HelloWorld,
+      name: 'Welcome',
+      component: Landing,
     },
     {
       path: '/auth/login',
@@ -23,5 +30,16 @@ export default new Router({
       name: 'Register',
       component: Register,
     },
+    {
+      path: '/discover',
+      name: 'Discover',
+      component: Discover,
+    },
+    // redundant
+    // {
+    //   path: '/debug/helloworld',
+    //   name: 'HelloWorld',
+    //   component: HelloWorld,
+    // },
   ],
 });

--- a/static/css/skeleton.css
+++ b/static/css/skeleton.css
@@ -243,7 +243,12 @@ input[type="button"].button-green:focus {
   background-color: #08db0c;
   border-color: #08db0c; }
 
-
+/* Custom
+-------------------------------------------------- */
+.button,
+button.standard-size {
+  min-width: 160px;
+}
   
 
 /* Forms


### PR DESCRIPTION
**What**
Setting up the `volunteero-gates` as a Landing Page site. 
Following the idea of separating the platform into _landing_ and _application_ part, we an extend the gates to be an only and hence complete landing website implementation.

**Changes**
In this pull request I added Landing and Discovery components and described the skeleton of the basic functionality these components will have to do. 

**Still to do**
A lot of stuff separately following the available stories in Trello: the browsing, narrative and actual authorization. Plus needs redirection from authorization if the user is already logged in. 